### PR TITLE
Add Apple AMX implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ set( CMAKE_COLOR_MAKEFILE ON )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
+### options
+
+if( APPLE )
+	option(ENABLE_APPLE_AMX "Allow usage of Apple's AMX instructions" OFF)
+endif()
+
 ### Optimizations
 if( MSVC )
 	add_compile_options( /arch:AVX2 )
@@ -75,6 +81,8 @@ elseif( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
 	)
 endif()
 
+
+### Main Targets
 add_library(
 	qAverageColor
 	STATIC
@@ -87,6 +95,15 @@ target_include_directories(
 	PUBLIC
 	include
 )
+
+if( ENABLE_APPLE_AMX )
+	target_compile_definitions(
+		qAverageColor
+		PRIVATE
+		ENABLE_APPLE_AMX
+	)
+endif()
+
 
 ### Tests
 if (PROJECT_IS_TOP_LEVEL)

--- a/source/amx.hpp
+++ b/source/amx.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#define AMX_NOP_OP_IMM5(op, imm5)                                              \
+	__asm("nop\nnop\nnop\n.word (0x201000 + (%0 << 5) + %1)"                   \
+		  :                                                                    \
+		  : "i"(op), "i"(imm5)                                                 \
+		  : "memory")
+
+#define AMX_OP_GPR(op, gpr)                                                    \
+	__asm(".word (0x201000 + (%0 << 5) + 0%1 - ((0%1 >> 4) * 6))"              \
+		  :                                                                    \
+		  : "i"(op), "r"((uint64_t)(gpr))                                      \
+		  : "memory")
+
+#define AMX_LDX(gpr) AMX_OP_GPR(0, gpr)
+#define AMX_LDY(gpr) AMX_OP_GPR(1, gpr)
+#define AMX_STX(gpr) AMX_OP_GPR(2, gpr)
+#define AMX_STY(gpr) AMX_OP_GPR(3, gpr)
+#define AMX_LDZ(gpr) AMX_OP_GPR(4, gpr)
+#define AMX_STZ(gpr) AMX_OP_GPR(5, gpr)
+#define AMX_LDZI(gpr) AMX_OP_GPR(6, gpr)
+#define AMX_STZI(gpr) AMX_OP_GPR(7, gpr)
+#define AMX_EXTRX(gpr) AMX_OP_GPR(8, gpr)
+#define AMX_EXTRY(gpr) AMX_OP_GPR(9, gpr)
+#define AMX_FMA64(gpr) AMX_OP_GPR(10, gpr)
+#define AMX_FMS64(gpr) AMX_OP_GPR(11, gpr)
+#define AMX_FMA32(gpr) AMX_OP_GPR(12, gpr)
+#define AMX_FMS32(gpr) AMX_OP_GPR(13, gpr)
+#define AMX_MAC16(gpr) AMX_OP_GPR(14, gpr)
+#define AMX_FMA16(gpr) AMX_OP_GPR(15, gpr)
+#define AMX_FMS16(gpr) AMX_OP_GPR(16, gpr)
+#define AMX_SET() AMX_NOP_OP_IMM5(17, 0)
+#define AMX_CLR() AMX_NOP_OP_IMM5(17, 1)
+#define AMX_VECINT(gpr) AMX_OP_GPR(18, gpr)
+#define AMX_VECFP(gpr) AMX_OP_GPR(19, gpr)
+#define AMX_MATINT(gpr) AMX_OP_GPR(20, gpr)
+#define AMX_MATFP(gpr) AMX_OP_GPR(21, gpr)
+#define AMX_GENLUT(gpr) AMX_OP_GPR(22, gpr)

--- a/source/qAverageColor-a64.cpp
+++ b/source/qAverageColor-a64.cpp
@@ -20,8 +20,8 @@ std::uint32_t
 
 #if defined(ENABLE_APPLE_AMX)
 
-	// 16 pixels at a time
-	for( std::size_t j = i / 16; j < Count / 16; j++ )
+	// 32 pixels at a time
+	for( std::size_t j = i / 32; j < Count / 32; j++ )
 	{
 		AMX_SET();
 
@@ -35,7 +35,12 @@ std::uint32_t
 			// 10: Z.u32[i] += f(X.u8[i], Y.u8[i])
 			// Produces 64 32-bit integers, requiring 256 bytes of data total!
 			// four rows of Z: interleaved quartet(perfect for RGBA!):
-			((10ULL) << 42);
+			((10ULL) << 42) |
+
+			// Perform operation on multiple vectors (M2 only)
+			((1ULL) << 31) |
+			// Multiple is x2
+			((0ULL) << 25);
 
 // In the worst case, where all the bytes are just 0xFF:
 // We are horizontally summing 4 channel-bytes at a time into a 32-bit
@@ -47,32 +52,45 @@ std::uint32_t
 //       | a saturated sum-value
 #define SPANDOT4 (0xFFFFFFFF / (0xFF * 4))
 
-		for( std::size_t k = 0; (k < SPANDOT4) && (j < Count / 16);
-			 k++, j++, i += 16 )
+		for( std::size_t k = 0; (k < SPANDOT4) && (j < Count / 32);
+			 k++, j++, i += 32 )
 #undef SPANDOT4
 		{
-			// Load 16 pixels
-			// Ensure to clear upper 8 bits
-			AMX_LDX(reinterpret_cast<std::uintptr_t>((const uint8_t*)&Pixels[i])
+			// Load 32 pixels
+			AMX_LDX(
+				reinterpret_cast<std::uintptr_t>((const uint8_t*)&Pixels[i])
+				| (1ULL << 62) // Load multiple registers
+				| (0ULL << 60) // Multiple registers means two registers
 			);
 
 			// Add each 64-bit value into a 32-bit sum across four rows of Z
-			// Z0: ASum32, ASum32, ASum32, ASum32...
-			// Z1: BSum32, BSum32, BSum32, BSum32...
-			// Z2: GSum32, GSum32, GSum32, GSum32...
-			// Z3: RSum32, RSum32, RSum32, RSum32...
+			// Z0: RSum32, ASum32, ASum32, ASum32...
+			// Z1: GSum32, BSum32, BSum32, BSum32...
+			// Z2: BSum32, GSum32, GSum32, GSum32...
+			// Z3: ASum32, RSum32, RSum32, RSum32...
 			AMX_VECINT(VecIntOp);
 		}
 		// Store each row of Z
 		// 16 * 4 32-bit accumulators
 		// This maps to four rows of AMX's Z register
-		// Each row is an ABGR channel
-		uint32x4x4_t ZMat[4] = {{}};
+		// Each row is an RGBA channel
+		uint32x4x4_t ZMat[8] = {{}};
 
 		for( std::size_t ZRow = 0; ZRow < 4; ++ZRow )
 		{
+			// Row index stored in upper 8 bits
 			AMX_STZ(
 				reinterpret_cast<std::uintptr_t>(&ZMat[ZRow]) | (ZRow << 56)
+			);
+		}
+
+		// Upper rows start at 32
+		for( std::size_t ZRow = 0; ZRow < 4; ++ZRow )
+		{
+			// Row index stored in upper 8 bits
+			AMX_STZ(
+				reinterpret_cast<std::uintptr_t>(&ZMat[ZRow + 4])
+				| ((ZRow + 32) << 56)
 			);
 		}
 
@@ -88,10 +106,29 @@ std::uint32_t
 				  + vaddvq_u32(ZMat[1].val[2]) + vaddvq_u32(ZMat[1].val[3]);
 		RedSum += vaddvq_u32(ZMat[0].val[0]) + vaddvq_u32(ZMat[0].val[1])
 				+ vaddvq_u32(ZMat[0].val[2]) + vaddvq_u32(ZMat[0].val[3]);
+
+		AlphaSum
+			+= vaddvq_u32(ZMat[3 + 4].val[0]) + vaddvq_u32(ZMat[3 + 4].val[1])
+			 + vaddvq_u32(ZMat[3 + 4].val[2]) + vaddvq_u32(ZMat[3 + 4].val[3]);
+		BlueSum
+			+= vaddvq_u32(ZMat[2 + 4].val[0]) + vaddvq_u32(ZMat[2 + 4].val[1])
+			 + vaddvq_u32(ZMat[2 + 4].val[2]) + vaddvq_u32(ZMat[2 + 4].val[3]);
+		GreenSum
+			+= vaddvq_u32(ZMat[1 + 4].val[0]) + vaddvq_u32(ZMat[1 + 4].val[1])
+			 + vaddvq_u32(ZMat[1 + 4].val[2]) + vaddvq_u32(ZMat[1 + 4].val[3]);
+		RedSum
+			+= vaddvq_u32(ZMat[0 + 4].val[0]) + vaddvq_u32(ZMat[0 + 4].val[1])
+			 + vaddvq_u32(ZMat[0 + 4].val[2]) + vaddvq_u32(ZMat[0 + 4].val[3]);
+
+		// Reset 32-bit sums
 		ZMat[0] = {};
 		ZMat[1] = {};
 		ZMat[2] = {};
 		ZMat[3] = {};
+		ZMat[4] = {};
+		ZMat[5] = {};
+		ZMat[6] = {};
+		ZMat[7] = {};
 	}
 
 #endif

--- a/source/qAverageColor-a64.cpp
+++ b/source/qAverageColor-a64.cpp
@@ -4,6 +4,10 @@
 
 #include <arm_neon.h>
 
+#if defined(ENABLE_APPLE_AMX)
+#include "amx.hpp"
+#endif
+
 std::uint32_t
 	qAverageColorRGBA8(const std::uint32_t Pixels[], std::size_t Count)
 {
@@ -13,6 +17,84 @@ std::uint32_t
 	std::uint64_t GreenSum = 0ULL;
 	std::uint64_t BlueSum  = 0ULL;
 	std::uint64_t AlphaSum = 0ULL;
+
+#if defined(ENABLE_APPLE_AMX)
+
+	// 16 pixels at a time
+	for( std::size_t j = i / 16; j < Count / 16; j++ )
+	{
+		AMX_SET();
+
+		const uint64_t VecIntOp =
+			// ALU mode
+			//  0 : f = Z+(X * Y) >> s
+			// 11 : f = Z+(X) >> s (M2 only)
+			((11ULL) << 47) |
+
+			// Lane width mode:
+			// 10: Z.u32[i] += f(X.u8[i], Y.u8[i])
+			// Produces 64 32-bit integers, requiring 256 bytes of data total!
+			// four rows of Z: interleaved quartet(perfect for RGBA!):
+			((10ULL) << 42);
+
+// In the worst case, where all the bytes are just 0xFF:
+// We are horizontally summing 4 channel-bytes at a time into a 32-bit
+// accumulator. The 32-bit accumulator would overflow after-
+// ( (0xFFFFFFFF / ( 0xFF * 4 ) ) = >>> 0x404040 iterations <<<
+//       ^             ^    ^ Number of bytes summed into accumulator
+//       |             |      at each iteration
+//       |             | a saturated color channel
+//       | a saturated sum-value
+#define SPANDOT4 (0xFFFFFFFF / (0xFF * 4))
+
+		for( std::size_t k = 0; (k < SPANDOT4) && (j < Count / 16);
+			 k++, j++, i += 16 )
+#undef SPANDOT4
+		{
+			// Load 16 pixels
+			// Ensure to clear upper 8 bits
+			AMX_LDX(reinterpret_cast<std::uintptr_t>((const uint8_t*)&Pixels[i])
+			);
+
+			// Add each 64-bit value into a 32-bit sum across four rows of Z
+			// Z0: ASum32, ASum32, ASum32, ASum32...
+			// Z1: BSum32, BSum32, BSum32, BSum32...
+			// Z2: GSum32, GSum32, GSum32, GSum32...
+			// Z3: RSum32, RSum32, RSum32, RSum32...
+			AMX_VECINT(VecIntOp);
+		}
+		// Store each row of Z
+		// 16 * 4 32-bit accumulators
+		// This maps to four rows of AMX's Z register
+		// Each row is an ABGR channel
+		uint32x4x4_t ZMat[4] = {{}};
+
+		for( std::size_t ZRow = 0; ZRow < 4; ++ZRow )
+		{
+			AMX_STZ(
+				reinterpret_cast<std::uintptr_t>(&ZMat[ZRow]) | (ZRow << 56)
+			);
+		}
+
+		AMX_CLR();
+
+		// To maintain safety from overflow, add the 32-bit sums into the 64-bit
+		// sums
+		AlphaSum += vaddvq_u32(ZMat[3].val[0]) + vaddvq_u32(ZMat[3].val[1])
+				  + vaddvq_u32(ZMat[3].val[2]) + vaddvq_u32(ZMat[3].val[3]);
+		BlueSum += vaddvq_u32(ZMat[2].val[0]) + vaddvq_u32(ZMat[2].val[1])
+				 + vaddvq_u32(ZMat[2].val[2]) + vaddvq_u32(ZMat[2].val[3]);
+		GreenSum += vaddvq_u32(ZMat[1].val[0]) + vaddvq_u32(ZMat[1].val[1])
+				  + vaddvq_u32(ZMat[1].val[2]) + vaddvq_u32(ZMat[1].val[3]);
+		RedSum += vaddvq_u32(ZMat[0].val[0]) + vaddvq_u32(ZMat[0].val[1])
+				+ vaddvq_u32(ZMat[0].val[2]) + vaddvq_u32(ZMat[0].val[3]);
+		ZMat[0] = {};
+		ZMat[1] = {};
+		ZMat[2] = {};
+		ZMat[3] = {};
+	}
+
+#endif
 
 	// 16 pixels at a time
 	for( std::size_t j = i / 16; j < Count / 16; j++ )

--- a/source/qAverageColor-a64.cpp
+++ b/source/qAverageColor-a64.cpp
@@ -28,12 +28,9 @@ std::uint32_t
 		// In the worst case, where all the bytes are just 0xFF being summed
 		// into a 32-bit accumulator, the 32-bit sum may overflow unless we
 		// ensure all 32-bit overflow-hazards are protected against.
-		// In this case:
-		// The maximum allowed sum is 0xFFFFFFFF / 16 due to the `vaddvq_u32`
-		// instructions at the end possibly allowing overflow.
-		// So `(0xFFFFFFFF / 16) / 0xFF == 0x404040` is the max amount of bytes
-		// we could ever safely accumulate.
-		const std::size_t LocalSumMaxIter = ((0xFFFFFFFF / 16) / 0xFF);
+		// In this case: `(0xFFFFFFFF / 0xFF == 0x1010101` is the max amount of
+		// bytes we could ever safely accumulate.
+		const std::size_t LocalSumMaxIter = (0xFFFFFFFF / 0xFF);
 		for( std::size_t k = 0; (k < LocalSumMaxIter) && (j < Count / 64);
 			 k++, j++, i += 64 )
 		{
@@ -96,22 +93,43 @@ std::uint32_t
 			 ++IterationIndex )
 		{
 			const std::size_t Off = IterationIndex * 4;
-			AlphaSum += vaddvq_u32(ZMat[3 + Off].val[0])
-					  + vaddvq_u32(ZMat[3 + Off].val[1])
-					  + vaddvq_u32(ZMat[3 + Off].val[2])
-					  + vaddvq_u32(ZMat[3 + Off].val[3]);
-			BlueSum += vaddvq_u32(ZMat[2 + Off].val[0])
-					 + vaddvq_u32(ZMat[2 + Off].val[1])
-					 + vaddvq_u32(ZMat[2 + Off].val[2])
-					 + vaddvq_u32(ZMat[2 + Off].val[3]);
-			GreenSum += vaddvq_u32(ZMat[1 + Off].val[0])
-					  + vaddvq_u32(ZMat[1 + Off].val[1])
-					  + vaddvq_u32(ZMat[1 + Off].val[2])
-					  + vaddvq_u32(ZMat[1 + Off].val[3]);
-			RedSum += vaddvq_u32(ZMat[0 + Off].val[0])
-					+ vaddvq_u32(ZMat[0 + Off].val[1])
-					+ vaddvq_u32(ZMat[0 + Off].val[2])
-					+ vaddvq_u32(ZMat[0 + Off].val[3]);
+			// Widening sums are used to ensure safety from overflow:
+			AlphaSum += vaddvq_u64(vpadalq_u32(
+				vpadalq_u32(
+					vpadalq_u32(
+						vpaddlq_u32(ZMat[3 + Off].val[0]), ZMat[3 + Off].val[1]
+					),
+					ZMat[3 + Off].val[2]
+				),
+				ZMat[3 + Off].val[3]
+			));
+			BlueSum += vaddvq_u64(vpadalq_u32(
+				vpadalq_u32(
+					vpadalq_u32(
+						vpaddlq_u32(ZMat[2 + Off].val[0]), ZMat[2 + Off].val[1]
+					),
+					ZMat[2 + Off].val[2]
+				),
+				ZMat[2 + Off].val[3]
+			));
+			GreenSum += vaddvq_u64(vpadalq_u32(
+				vpadalq_u32(
+					vpadalq_u32(
+						vpaddlq_u32(ZMat[1 + Off].val[0]), ZMat[1 + Off].val[1]
+					),
+					ZMat[1 + Off].val[2]
+				),
+				ZMat[1 + Off].val[3]
+			));
+			RedSum += vaddvq_u64(vpadalq_u32(
+				vpadalq_u32(
+					vpadalq_u32(
+						vpaddlq_u32(ZMat[0 + Off].val[0]), ZMat[0 + Off].val[1]
+					),
+					ZMat[0 + Off].val[2]
+				),
+				ZMat[0 + Off].val[3]
+			));
 		}
 	}
 

--- a/source/qAverageColor-a64.cpp
+++ b/source/qAverageColor-a64.cpp
@@ -19,7 +19,6 @@ std::uint32_t
 	std::uint64_t AlphaSum = 0ULL;
 
 #if defined(ENABLE_APPLE_AMX)
-
 	// 64 pixels at a time
 	for( std::size_t j = i / 64; j < Count / 64; j++ )
 	{
@@ -30,8 +29,8 @@ std::uint32_t
 		// ensure all 32-bit overflow-hazards are protected against.
 		// In this case: `(0xFFFFFFFF / 0xFF == 0x1010101` is the max amount of
 		// bytes we could ever safely accumulate.
-		const std::size_t LocalSumMaxIter = (0xFFFFFFFF / 0xFF);
-		for( std::size_t k = 0; (k < LocalSumMaxIter) && (j < Count / 64);
+		const std::size_t LocalSumOverflowMax = (0xFFFFFFFF / 0xFF);
+		for( std::size_t k = 0; (k < LocalSumOverflowMax) && (j < Count / 64);
 			 k++, j++, i += 64 )
 		{
 			// Load 32 pixels
@@ -41,7 +40,7 @@ std::uint32_t
 				| (1ULL << 60) // Load four times
 			);
 
-			const uint64_t VecIntOp =
+			constexpr std::uint64_t VecIntOp =
 				// ALU mode
 				//  0 : f = Z+(X * Y) >> s
 				// 11 : f = Z+(X) >> s (M2 only)
@@ -55,14 +54,14 @@ std::uint32_t
 
 				// Iterate multple times (M2 only)
 				((1ULL) << 31) |
-				// Iterate x4 times
+				// Iterate x4 times (M2 only)
 				((1ULL) << 25);
 
 			// Add each 64-bit value into a 32-bit sum across four rows of Z
-			// Z0: RSum32, ASum32, ASum32, ASum32...
-			// Z1: GSum32, BSum32, BSum32, BSum32...
-			// Z2: BSum32, GSum32, GSum32, GSum32...
-			// Z3: ASum32, RSum32, RSum32, RSum32...
+			// Z0 + Iter * 16: RSum32, ASum32, ASum32, ASum32...
+			// Z1 + Iter * 16: GSum32, BSum32, BSum32, BSum32...
+			// Z2 + Iter * 16: BSum32, GSum32, GSum32, GSum32...
+			// Z3 + Iter * 16: ASum32, RSum32, RSum32, RSum32...
 			AMX_VECINT(VecIntOp);
 		}
 
@@ -88,48 +87,50 @@ std::uint32_t
 
 		AMX_CLR();
 
-		// To maintain safety from overflow, add the 32-bit sums into the 64-bit
-		// sums
 		for( std::size_t IterationIndex = 0; IterationIndex < 4;
 			 ++IterationIndex )
 		{
-			const std::size_t Off = IterationIndex * 4;
-			// Widening sums are used to ensure safety from overflow:
+			const std::size_t IterationOffset = IterationIndex * 4;
+			// Widening pair-wise sums are used to ensure safety from overflow
 			AlphaSum += vaddvq_u64(vpadalq_u32(
 				vpadalq_u32(
 					vpadalq_u32(
-						vpaddlq_u32(ZMat[3 + Off].val[0]), ZMat[3 + Off].val[1]
+						vpaddlq_u32(ZMat[3 + IterationOffset].val[0]),
+						ZMat[3 + IterationOffset].val[1]
 					),
-					ZMat[3 + Off].val[2]
+					ZMat[3 + IterationOffset].val[2]
 				),
-				ZMat[3 + Off].val[3]
+				ZMat[3 + IterationOffset].val[3]
 			));
 			BlueSum += vaddvq_u64(vpadalq_u32(
 				vpadalq_u32(
 					vpadalq_u32(
-						vpaddlq_u32(ZMat[2 + Off].val[0]), ZMat[2 + Off].val[1]
+						vpaddlq_u32(ZMat[2 + IterationOffset].val[0]),
+						ZMat[2 + IterationOffset].val[1]
 					),
-					ZMat[2 + Off].val[2]
+					ZMat[2 + IterationOffset].val[2]
 				),
-				ZMat[2 + Off].val[3]
+				ZMat[2 + IterationOffset].val[3]
 			));
 			GreenSum += vaddvq_u64(vpadalq_u32(
 				vpadalq_u32(
 					vpadalq_u32(
-						vpaddlq_u32(ZMat[1 + Off].val[0]), ZMat[1 + Off].val[1]
+						vpaddlq_u32(ZMat[1 + IterationOffset].val[0]),
+						ZMat[1 + IterationOffset].val[1]
 					),
-					ZMat[1 + Off].val[2]
+					ZMat[1 + IterationOffset].val[2]
 				),
-				ZMat[1 + Off].val[3]
+				ZMat[1 + IterationOffset].val[3]
 			));
 			RedSum += vaddvq_u64(vpadalq_u32(
 				vpadalq_u32(
 					vpadalq_u32(
-						vpaddlq_u32(ZMat[0 + Off].val[0]), ZMat[0 + Off].val[1]
+						vpaddlq_u32(ZMat[0 + IterationOffset].val[0]),
+						ZMat[0 + IterationOffset].val[1]
 					),
-					ZMat[0 + Off].val[2]
+					ZMat[0 + IterationOffset].val[2]
 				),
-				ZMat[0 + Off].val[3]
+				ZMat[0 + IterationOffset].val[3]
 			));
 		}
 	}

--- a/source/qAverageColor-a64.cpp
+++ b/source/qAverageColor-a64.cpp
@@ -72,15 +72,16 @@ std::uint32_t
 		for( std::size_t IterationIndex = 0; IterationIndex < 4;
 			 ++IterationIndex )
 		{
-			for( std::size_t ZRow = 0; ZRow < 4; ++ZRow )
+			for( std::size_t ZRow = 0; ZRow < 4; ZRow += 2 )
 			{
-				// Row index stored in upper 8 bits
+				// Store 64*2-byte pairs of rows of Z
 				AMX_STZ(
 					reinterpret_cast<std::uintptr_t>(
 						&ZMat[ZRow + 4 * IterationIndex]
 					)
 					| static_cast<std::uint64_t>(ZRow + 16 * IterationIndex)
 						  << 56
+					| 1ULL << 62
 				);
 			}
 		}

--- a/source/qAverageColor-a64.cpp
+++ b/source/qAverageColor-a64.cpp
@@ -25,19 +25,17 @@ std::uint32_t
 	{
 		AMX_SET();
 
-// In the worst case, where all the bytes are just 0xFF:
-// We are horizontally summing 4 channel-bytes at a time into a 32-bit
-// accumulator. The 32-bit accumulator would overflow after-
-// ( (0xFFFFFFFF / ( 0xFF * 4 ) ) = >>> 0x404040 iterations <<<
-//       ^             ^    ^ Number of bytes summed into accumulator
-//       |             |      at each iteration
-//       |             | a saturated color channel
-//       | a saturated sum-value
-#define SPANDOT4 (0xFFFFFFFF / (0xFF * 4))
-
-		for( std::size_t k = 0; (k < SPANDOT4) && (j < Count / 64);
+		// In the worst case, where all the bytes are just 0xFF being summed
+		// into a 32-bit accumulator, the 32-bit sum may overflow unless we
+		// ensure all 32-bit overflow-hazards are protected against.
+		// In this case:
+		// The maximum allowed sum is 0xFFFFFFFF / 16 due to the `vaddvq_u32`
+		// instructions at the end possibly allowing overflow.
+		// So `(0xFFFFFFFF / 16) / 0xFF == 0x404040` is the max amount of bytes
+		// we could ever safely accumulate.
+		const std::size_t LocalSumMaxIter = ((0xFFFFFFFF / 16) / 0xFF);
+		for( std::size_t k = 0; (k < LocalSumMaxIter) && (j < Count / 64);
 			 k++, j++, i += 64 )
-#undef SPANDOT4
 		{
 			// Load 32 pixels
 			AMX_LDX(

--- a/source/qAverageColor-a64.cpp
+++ b/source/qAverageColor-a64.cpp
@@ -20,27 +20,10 @@ std::uint32_t
 
 #if defined(ENABLE_APPLE_AMX)
 
-	// 32 pixels at a time
-	for( std::size_t j = i / 32; j < Count / 32; j++ )
+	// 64 pixels at a time
+	for( std::size_t j = i / 64; j < Count / 64; j++ )
 	{
 		AMX_SET();
-
-		const uint64_t VecIntOp =
-			// ALU mode
-			//  0 : f = Z+(X * Y) >> s
-			// 11 : f = Z+(X) >> s (M2 only)
-			((11ULL) << 47) |
-
-			// Lane width mode:
-			// 10: Z.u32[i] += f(X.u8[i], Y.u8[i])
-			// Produces 64 32-bit integers, requiring 256 bytes of data total!
-			// four rows of Z: interleaved quartet(perfect for RGBA!):
-			((10ULL) << 42) |
-
-			// Perform operation on multiple vectors (M2 only)
-			((1ULL) << 31) |
-			// Multiple is x2
-			((0ULL) << 25);
 
 // In the worst case, where all the bytes are just 0xFF:
 // We are horizontally summing 4 channel-bytes at a time into a 32-bit
@@ -52,16 +35,33 @@ std::uint32_t
 //       | a saturated sum-value
 #define SPANDOT4 (0xFFFFFFFF / (0xFF * 4))
 
-		for( std::size_t k = 0; (k < SPANDOT4) && (j < Count / 32);
-			 k++, j++, i += 32 )
+		for( std::size_t k = 0; (k < SPANDOT4) && (j < Count / 64);
+			 k++, j++, i += 64 )
 #undef SPANDOT4
 		{
 			// Load 32 pixels
 			AMX_LDX(
 				reinterpret_cast<std::uintptr_t>((const uint8_t*)&Pixels[i])
-				| (1ULL << 62) // Load multiple registers
-				| (0ULL << 60) // Multiple registers means two registers
+				| (1ULL << 62) // Load multiple times
+				| (1ULL << 60) // Load four times
 			);
+
+			const uint64_t VecIntOp =
+				// ALU mode
+				//  0 : f = Z+(X * Y) >> s
+				// 11 : f = Z+(X) >> s (M2 only)
+				((11ULL) << 47) |
+				// Lane width mode:
+				// 10: Z.u32[i] += f(X.u8[i], Y.u8[i])
+				// Produces 64 32-bit integers, requiring 256 bytes of data
+				// total! four rows of Z: interleaved quartet(perfect for
+				// RGBA!):
+				((10ULL) << 42) |
+
+				// Iterate multple times (M2 only)
+				((1ULL) << 31) |
+				// Iterate x4 times
+				((1ULL) << 25);
 
 			// Add each 64-bit value into a 32-bit sum across four rows of Z
 			// Z0: RSum32, ASum32, ASum32, ASum32...
@@ -70,65 +70,51 @@ std::uint32_t
 			// Z3: ASum32, RSum32, RSum32, RSum32...
 			AMX_VECINT(VecIntOp);
 		}
-		// Store each row of Z
-		// 16 * 4 32-bit accumulators
-		// This maps to four rows of AMX's Z register
+
 		// Each row is an RGBA channel
-		uint32x4x4_t ZMat[8] = {{}};
+		uint32x4x4_t ZMat[4 * 4] = {{}};
 
-		for( std::size_t ZRow = 0; ZRow < 4; ++ZRow )
+		for( std::size_t IterationIndex = 0; IterationIndex < 4;
+			 ++IterationIndex )
 		{
-			// Row index stored in upper 8 bits
-			AMX_STZ(
-				reinterpret_cast<std::uintptr_t>(&ZMat[ZRow]) | (ZRow << 56)
-			);
-		}
-
-		// Upper rows start at 32
-		for( std::size_t ZRow = 0; ZRow < 4; ++ZRow )
-		{
-			// Row index stored in upper 8 bits
-			AMX_STZ(
-				reinterpret_cast<std::uintptr_t>(&ZMat[ZRow + 4])
-				| ((ZRow + 32) << 56)
-			);
+			for( std::size_t ZRow = 0; ZRow < 4; ++ZRow )
+			{
+				// Row index stored in upper 8 bits
+				AMX_STZ(
+					reinterpret_cast<std::uintptr_t>(
+						&ZMat[ZRow + 4 * IterationIndex]
+					)
+					| static_cast<std::uint64_t>(ZRow + 16 * IterationIndex)
+						  << 56
+				);
+			}
 		}
 
 		AMX_CLR();
 
 		// To maintain safety from overflow, add the 32-bit sums into the 64-bit
 		// sums
-		AlphaSum += vaddvq_u32(ZMat[3].val[0]) + vaddvq_u32(ZMat[3].val[1])
-				  + vaddvq_u32(ZMat[3].val[2]) + vaddvq_u32(ZMat[3].val[3]);
-		BlueSum += vaddvq_u32(ZMat[2].val[0]) + vaddvq_u32(ZMat[2].val[1])
-				 + vaddvq_u32(ZMat[2].val[2]) + vaddvq_u32(ZMat[2].val[3]);
-		GreenSum += vaddvq_u32(ZMat[1].val[0]) + vaddvq_u32(ZMat[1].val[1])
-				  + vaddvq_u32(ZMat[1].val[2]) + vaddvq_u32(ZMat[1].val[3]);
-		RedSum += vaddvq_u32(ZMat[0].val[0]) + vaddvq_u32(ZMat[0].val[1])
-				+ vaddvq_u32(ZMat[0].val[2]) + vaddvq_u32(ZMat[0].val[3]);
-
-		AlphaSum
-			+= vaddvq_u32(ZMat[3 + 4].val[0]) + vaddvq_u32(ZMat[3 + 4].val[1])
-			 + vaddvq_u32(ZMat[3 + 4].val[2]) + vaddvq_u32(ZMat[3 + 4].val[3]);
-		BlueSum
-			+= vaddvq_u32(ZMat[2 + 4].val[0]) + vaddvq_u32(ZMat[2 + 4].val[1])
-			 + vaddvq_u32(ZMat[2 + 4].val[2]) + vaddvq_u32(ZMat[2 + 4].val[3]);
-		GreenSum
-			+= vaddvq_u32(ZMat[1 + 4].val[0]) + vaddvq_u32(ZMat[1 + 4].val[1])
-			 + vaddvq_u32(ZMat[1 + 4].val[2]) + vaddvq_u32(ZMat[1 + 4].val[3]);
-		RedSum
-			+= vaddvq_u32(ZMat[0 + 4].val[0]) + vaddvq_u32(ZMat[0 + 4].val[1])
-			 + vaddvq_u32(ZMat[0 + 4].val[2]) + vaddvq_u32(ZMat[0 + 4].val[3]);
-
-		// Reset 32-bit sums
-		ZMat[0] = {};
-		ZMat[1] = {};
-		ZMat[2] = {};
-		ZMat[3] = {};
-		ZMat[4] = {};
-		ZMat[5] = {};
-		ZMat[6] = {};
-		ZMat[7] = {};
+		for( std::size_t IterationIndex = 0; IterationIndex < 4;
+			 ++IterationIndex )
+		{
+			const std::size_t Off = IterationIndex * 4;
+			AlphaSum += vaddvq_u32(ZMat[3 + Off].val[0])
+					  + vaddvq_u32(ZMat[3 + Off].val[1])
+					  + vaddvq_u32(ZMat[3 + Off].val[2])
+					  + vaddvq_u32(ZMat[3 + Off].val[3]);
+			BlueSum += vaddvq_u32(ZMat[2 + Off].val[0])
+					 + vaddvq_u32(ZMat[2 + Off].val[1])
+					 + vaddvq_u32(ZMat[2 + Off].val[2])
+					 + vaddvq_u32(ZMat[2 + Off].val[3]);
+			GreenSum += vaddvq_u32(ZMat[1 + Off].val[0])
+					  + vaddvq_u32(ZMat[1 + Off].val[1])
+					  + vaddvq_u32(ZMat[1 + Off].val[2])
+					  + vaddvq_u32(ZMat[1 + Off].val[3]);
+			RedSum += vaddvq_u32(ZMat[0 + Off].val[0])
+					+ vaddvq_u32(ZMat[0 + Off].val[1])
+					+ vaddvq_u32(ZMat[0 + Off].val[2])
+					+ vaddvq_u32(ZMat[0 + Off].val[3]);
+		}
 	}
 
 #endif


### PR DESCRIPTION
Uses the [vecint](https://github.com/corsix/amx/blob/42a391b9b77c9191fd8b8fa39b05e5f67cb6bd48/vecint.md) instruction to accumulate the RGBA channels of `16*4` pixels into `64*4` sums in parallel. Implementation is similar to the `UDOT` instruction provided on A64, but performs better in my testing.